### PR TITLE
editted the workflow of the game probabilities (past, current, prob tables)

### DIFF
--- a/backend/sports-betting-db.sql
+++ b/backend/sports-betting-db.sql
@@ -32,8 +32,44 @@ CREATE TABLE current_game_info (
     away_team VARCHAR(50) NOT NULL,
     away_team_score INT NOT NULL,
     game_time_elapsed TIME NOT NULL,
-    game_stadium VARCHAR(50)
+    game_stadium VARCHAR(50),
+    home_win_probability FLOAT,
+    away_win_probability FLOAT,
+    probability_last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE past_game_info (
+    past_game_id INT PRIMARY KEY,
+    game_date DATE NOT NULL,
+    home_team VARCHAR(50) NOT NULL,
+    home_team_score INT NOT NULL,
+    away_team VARCHAR(50) NOT NULL,
+    away_team_score INT NOT NULL,
+    game_time_elapsed TIME NOT NULL,
+    game_stadium VARCHAR(50),
+    home_win_probability FLOAT,
+    away_win_probability FLOAT,
+    probability_last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Table to store historical probability calculations (every 5 seconds during the game)
+-- This table tracks ALL probability calculations for both current and past games
+CREATE TABLE game_probability_history (
+    probability_id SERIAL PRIMARY KEY,
+    game_id INT NOT NULL,
+    calculation_timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    game_time_elapsed TIME NOT NULL,
+    quarter INT,
+    home_team_score INT NOT NULL,
+    away_team_score INT NOT NULL,
+    home_win_probability FLOAT NOT NULL,
+    away_win_probability FLOAT NOT NULL,
+    llm_model_version VARCHAR(50)
+);
+
+-- Index for efficient querying of probability history by game and time
+CREATE INDEX idx_game_timestamp ON game_probability_history(game_id, calculation_timestamp);
+
 -- Table to hold info for the players that are currently playing in the game
 CREATE TABLE player_in_game_info (
     player_in_game_id INT PRIMARY KEY,


### PR DESCRIPTION
- Created a game probability history table to store a list of the game probabilities for a specific game
- Connected the workflows between current_game_info, past_game_info, and game_probability history
- game prob history tables stores game_id but no foreign key constraints to allow for insertion into the live games and query from past games