### PR TITLE
lm - refactored connection manager to support topic ws

### DIFF
--- a/backend/documents/api-reference.md
+++ b/backend/documents/api-reference.md
@@ -170,18 +170,36 @@ Frontend guidance:
 ## WebSocket
 
 ### `WS /ws`
-Push channel for live game snapshots.
+Topic-based push channel for live game updates.
 
 Behavior:
-- Server accepts connection and stores socket in a connection manager.
-- On each 5-second poll, server broadcasts full array payload (same shape as `GET /api/games`).
-- In the websocket handler loop, server waits for incoming text from client (`await websocket.receive_text()`).
+- Server accepts connection and auto-subscribes client to `games` topic.
+- Clients can subscribe/unsubscribe to specific topics by sending JSON text messages.
+- On each 5-second poll:
+  - Topic `games` receives full array payload (same shape as `GET /api/games`).
+  - Topic `game:<game_id>` receives one game object for that game id.
 
 Client requirement:
-- Send heartbeat text periodically or keepalive messages to avoid idle disconnect in environments that require activity.
+- Send heartbeat text periodically (non-JSON text is ignored).
+- Send JSON messages to manage topic subscriptions.
 
-Message payload shape:
-- JSON-encoded `GameWithProbability[]`.
+Client -> Server messages:
+
+```json
+{"action":"subscribe","topic":"games"}
+{"action":"subscribe","topic":"game:401706123"}
+{"action":"unsubscribe","topic":"game:401706123"}
+```
+
+Server ack message:
+
+```json
+{"ok":true,"action":"subscribe","topic":"games"}
+```
+
+Server -> Client payload shapes:
+- Topic `games`: JSON-encoded `GameWithProbability[]`
+- Topic `game:<game_id>`: JSON-encoded `GameWithProbability`
 
 ## CORS
 

--- a/backend/documents/backend-architecture.md
+++ b/backend/documents/backend-architecture.md
@@ -9,7 +9,7 @@ Primary flow:
 2. Parse each event into normalized game objects.
 3. Compute win probabilities per game.
 4. Store results in in-memory module state.
-5. Broadcast full snapshot to active WebSocket clients.
+5. Broadcast topic-based updates to subscribed WebSocket clients.
 
 ## Core Modules
 
@@ -51,8 +51,13 @@ Primary flow:
 ## WebSocket Broadcast Model
 
 - WebSocket clients connect to `/ws`.
-- On each poll tick, backend broadcasts the full games array as JSON text.
-- Failed sends are currently swallowed in `broadcast_json`.
+- Clients are tracked by topic in memory (topic -> websocket set).
+- Default subscription on connect: `games`.
+- Supported topics:
+  - `games` -> full game snapshot array.
+  - `game:<game_id>` -> per-game payload for one game.
+- On each poll tick, backend broadcasts to each topic independently.
+- Disconnect removes the socket from all subscribed topics.
 
 ## CORS/Frontend Integration
 

--- a/backend/documents/frontend-contracts.md
+++ b/backend/documents/frontend-contracts.md
@@ -107,13 +107,35 @@ export type LeagueStandingsResponse = LeagueStandingsItem[];
 ### Endpoint
 - `ws://<host>/ws`
 
-### Server-to-client event
-- Message type: text frame containing JSON string.
-- Parsed payload: `GameWithProbability[]`
+### Topics
+- `games`: full snapshot stream (`GameWithProbability[]`).
+- `game:<game_id>`: single-game stream (`GameWithProbability`).
 
-### Client-to-server expectation
-- Backend currently waits for incoming text frames in a loop.
-- Frontend should send periodic heartbeat text (for example every 20-30s) to keep connection behavior predictable.
+### Client-to-server messages
+- Message type: text frame containing JSON.
+- Subscribe:
+```json
+{"action":"subscribe","topic":"games"}
+```
+- Subscribe to one game:
+```json
+{"action":"subscribe","topic":"game:401706123"}
+```
+- Unsubscribe:
+```json
+{"action":"unsubscribe","topic":"game:401706123"}
+```
+- Heartbeat:
+  - Non-JSON text is allowed and ignored by backend.
+
+### Server-to-client events
+- Message type: text frame containing JSON.
+- Subscription ack shape:
+```json
+{"ok":true,"action":"subscribe","topic":"games"}
+```
+- `games` topic payload: `GameWithProbability[]`.
+- `game:<game_id>` topic payload: `GameWithProbability`.
 
 ## Contract Caveats
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -138,8 +138,26 @@ async def update_games_and_probabilities():
     app_state.probabilities.update(probabilities)
     
     result = merge_gp(games, probabilities)
-    print(f"Broadcasting {len(result)} games to {len(manager.active_connections)} clients\n")
-    await manager.broadcast_json(result)
+    games_targets = manager.topic_connection_labels("games")
+    print(
+        f"[broadcast] topic=games payload=GameWithProbability[] games={len(result)} "
+        f"subscribers={len(games_targets)} active_total={len(manager.active_connections)} "
+        f"targets={games_targets}"
+    )
+    # Broadcast to games dashboard
+    await manager.broadcast_to_topic("games", result)
+    # Broadcast to singel gameID (todo: remove and create separate function to send per game stats needed)
+    for game in result:
+        game_id = game.get("game_id")
+        if game_id:
+            topic = f"game:{game_id}"
+            topic_targets = manager.topic_connection_labels(topic)
+            if topic_targets:
+                print(
+                    f"[broadcast] topic={topic} payload=GameWithProbability "
+                    f"subscribers={len(topic_targets)} targets={topic_targets}"
+                )
+            await manager.broadcast_to_topic(topic, game)
 
 async def poll_loop():
     """Poll the NBA API every 5 seconds and update the games and probabilities."""
@@ -154,23 +172,84 @@ async def poll_loop():
 
 class ConnectionManager:
     def __init__(self):
-        self.active_connections: list[WebSocket] = []
+        self.active_connections: set[WebSocket] = set()
+        self.topic_connections: dict[str, set[WebSocket]] = {}
+        self.connection_topics: dict[WebSocket, set[str]] = {}
 
     async def connect(self, websocket: WebSocket):
         await websocket.accept()
-        self.active_connections.append(websocket)
+        self.active_connections.add(websocket)
+        # Keep existing clients working by defaulting to the aggregate stream.
+        await self.subscribe(websocket, "games")
+        print(
+            f"[ws] connected client={self.connection_label(websocket)} "
+            f"active_total={len(self.active_connections)}"
+        )
 
     async def disconnect(self, websocket: WebSocket):
-        if websocket in self.active_connections:
-            self.active_connections.remove(websocket)
+        topics = list(self.connection_topics.get(websocket, set()))
+        for topic in topics:
+            await self.unsubscribe(websocket, topic)
+        self.connection_topics.pop(websocket, None)
+        self.active_connections.discard(websocket)
+        print(
+            f"[ws] disconnected client={self.connection_label(websocket)} "
+            f"active_total={len(self.active_connections)}"
+        )
 
-    async def broadcast_json(self, payload: Any):
+    async def subscribe(self, websocket: WebSocket, topic: str):
+        if not topic:
+            return
+        self.topic_connections.setdefault(topic, set()).add(websocket)
+        self.connection_topics.setdefault(websocket, set()).add(topic)
+        print(
+            f"[ws] subscribe client={self.connection_label(websocket)} "
+            f"topic={topic} subscribers={self.topic_size(topic)}"
+        )
+
+    async def unsubscribe(self, websocket: WebSocket, topic: str):
+        subscribers = self.topic_connections.get(topic)
+        if not subscribers:
+            return
+        subscribers.discard(websocket)
+        if not subscribers:
+            self.topic_connections.pop(topic, None)
+
+        topics = self.connection_topics.get(websocket)
+        if topics:
+            topics.discard(topic)
+            if not topics:
+                self.connection_topics.pop(websocket, None)
+        print(
+            f"[ws] unsubscribe client={self.connection_label(websocket)} "
+            f"topic={topic} subscribers={self.topic_size(topic)}"
+        )
+
+    def topic_size(self, topic: str) -> int:
+        return len(self.topic_connections.get(topic, set()))
+
+    def connection_label(self, websocket: WebSocket) -> str:
+        client = websocket.client
+        if client:
+            return f"{client.host}:{client.port}"
+        return f"ws:{id(websocket)}"
+
+    def topic_connection_labels(self, topic: str) -> list[str]:
+        return [self.connection_label(c) for c in self.topic_connections.get(topic, set())]
+
+    async def broadcast_to_topic(self, topic: str, payload: Any):
+        subscribers = list(self.topic_connections.get(topic, set()))
+        if not subscribers:
+            return
         txt = json.dumps(payload)
-        for c in self.active_connections:
+        dead_connections: list[WebSocket] = []
+        for c in subscribers:
             try:
                 await c.send_text(txt)
             except Exception:
-                pass
+                dead_connections.append(c)
+        for c in dead_connections:
+            await self.disconnect(c)
 
 
 manager = ConnectionManager()
@@ -458,6 +537,26 @@ async def websocket_endpoint(websocket: WebSocket):
     await manager.connect(websocket)
     try:
         while True:
-            await websocket.receive_text()
+            message = await websocket.receive_text()
+            if not message:
+                continue
+
+            action = None
+            topic = None
+            try:
+                payload = json.loads(message)
+                if isinstance(payload, dict):
+                    action = payload.get("action") or payload.get("type")
+                    topic = payload.get("topic")
+            except json.JSONDecodeError:
+                # Ignore non-JSON heartbeat text.
+                continue
+
+            if action == "subscribe" and isinstance(topic, str):
+                await manager.subscribe(websocket, topic)
+                await websocket.send_json({"ok": True, "action": "subscribe", "topic": topic})
+            elif action == "unsubscribe" and isinstance(topic, str):
+                await manager.unsubscribe(websocket, topic)
+                await websocket.send_json({"ok": True, "action": "unsubscribe", "topic": topic})
     except WebSocketDisconnect:
         await manager.disconnect(websocket)

--- a/backend/util.py
+++ b/backend/util.py
@@ -18,17 +18,26 @@ import pandas as pd
 
 _ML_MODEL_PATH = Path(__file__).resolve().parent.parent / "ml" / "nn.joblib"
 _wp_model = None
+_wp_model_load_attempted = False
 
 def _load_wp_model():
-    """Load the win-probability model once; returns None if file missing."""
-    global _wp_model
+    """Load the win-probability model once; returns None when unavailable or unloadable."""
+    global _wp_model, _wp_model_load_attempted
     if _wp_model is not None:
         return _wp_model
-    if not _ML_MODEL_PATH.is_file():
+    if _wp_model_load_attempted:
         return None
-    import joblib
-    _wp_model = joblib.load(_ML_MODEL_PATH)
-    return _wp_model
+    _wp_model_load_attempted = True
+    if not _ML_MODEL_PATH.is_file():
+        print(f"WP model not found at {_ML_MODEL_PATH}; using fallback probabilities.")
+        return None
+    try:
+        import joblib
+        _wp_model = joblib.load(_ML_MODEL_PATH)
+        return _wp_model
+    except Exception as e:
+        print(f"WP model load failed ({_ML_MODEL_PATH}): {e}. Using fallback probabilities.")
+        return None
 
 _SEC_PER_QUARTER = 720
 _SEC_TOTAL_REGULATION = 2880


### PR DESCRIPTION
Closes #139 

This PR upgrades the backend WebSocket delivery from global broadcast to topic-based subscriptions and adds new documentation. It also add fall back to probability model loading for missing ML dependencies that doesn't break polling loop.

- Added topic registries
- Added methods for subscribe(websocket, topic), unsibscribe(websocket, topic), broadcast_to_topic(topic, payload)
- Per-topic broadcasting
- /ws handler now processes subscription commands

**How to test**

1. Run backend:
```bash
cd backend
uvicorn main:app --reload
```
2. Connect via WebScoket on separate terminal (may need to install wscat)
```bash
wscat -c ws://127.0.0.1:8000/ws
```
3. Subscribe to single game:
```bash
{"action":"subscribe","topic":"game:<game_id>"}
```
Expect single-game payloads for that topic on poll ticks.
4. Unsubscribe:
```bash
{"action":"unsubscribe","topic":"game:<game_id>"}
```
Expect stream to stop for that topic
5. Confirm terminal logs for active connections and topic subscription counts