### PR TITLE
lm - implemented regex to detect vercel deployment in CORSMiddleware

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -271,7 +271,8 @@ app = FastAPI(lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000", "http://127.0.0.1:3000", "https://pj09-sports-betting.vercel.app"],
+    allow_origins=["http://localhost:3000", "http://127.0.0.1:3000", "https://pj09-sports-betting.vercel.app", "https://pj09-sports-betting-2enq4id18-kevins-projects-8b1f5231.vercel.app"],
+    allow_origin_regex=r"^https://pj09-sports-betting(?:-[a-z0-9-]+)?\.vercel\.app$",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
Closes #131 

This PR reattempts to resolve the CORS issue between our production deployments. Currently the backend does not allow the frontend to call the REST APIs on the backend without getting a CORS error. I believe the likely cause is that the shortened production URL is not the actual origin that is being sent in the requests and therefore was not one of the allowed origins from the changes implemented in #107. To resolve this, I used the actual production URL found in the deployment section on github, adding to our allowed origins in the CORS middleware and also added a regex for allowed origin that are close to our shortened production URL.