### PR TITLE
added lineup metholody by salary

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -15,6 +15,7 @@ from util import (
     parse_dashboard_game_data,
     merge_gp,
     fetch_espn_lineups,
+    fetch_salary_based_lineups,
     fetch_standings_from_espn,
     fetch_games_from_nba,
     fetch_dashboard_games,
@@ -320,8 +321,9 @@ def get_player_props(game_date: str):
     """
     Returns player PTS, REB, and AST props for all players in lineups on a certain date.
     Also includes over/under lines from different bookmakers (platforms).
+    Uses salary-based projected lineups so data is available before tip-off.
     """
-    lineups = fetch_espn_lineups(game_date)
+    lineups = fetch_salary_based_lineups(game_date)
     if not lineups:
         return {
             "error": "No lineups found",
@@ -384,7 +386,7 @@ def get_lineups(game_date: str):
         }
 
     try:
-        return fetch_espn_lineups(game_date)
+        return fetch_salary_based_lineups(game_date)
     except requests.exceptions.Timeout:
         return {
             "error": "Request timeout. ESPN may be slow or unavailable.",

--- a/backend/util.py
+++ b/backend/util.py
@@ -553,6 +553,265 @@ def parse_lineup_data(raw_data: dict, game_date: str) -> dict:  # noqa: ARG001
     """Deprecated — prefer ``fetch_espn_lineups(game_date)`` instead."""
     return fetch_espn_lineups(game_date)
 
+
+# ── Salary-based starting lineups ─────────────────────────────────────
+# ESPN roster API team slug mapping (abbreviation -> ESPN team slug used in URL)
+_ESPN_TEAM_SLUGS: dict[str, str] = {
+    "ATL": "atl", "BOS": "bos", "BKN": "bkn", "CHA": "cha",
+    "CHI": "chi", "CLE": "cle", "DAL": "dal", "DEN": "den",
+    "DET": "det", "GSW": "gs",  "HOU": "hou", "IND": "ind",
+    "LAC": "lac", "LAL": "lal", "MEM": "mem", "MIA": "mia",
+    "MIL": "mil", "MIN": "min", "NOP": "no",  "NYK": "ny",
+    "OKC": "okc", "ORL": "orl", "PHI": "phi", "PHX": "phx",
+    "POR": "por", "SAC": "sac", "SAS": "sa",  "TOR": "tor",
+    "UTA": "utah", "WAS": "wsh",
+}
+
+# Cache for team rosters to avoid repeated API calls within a short window
+_ROSTER_CACHE: dict[str, list[dict[str, Any]]] = {}
+_ROSTER_CACHE_AT: dict[str, datetime] = {}
+_ROSTER_CACHE_TTL = 3600  # 1 hour
+
+
+def _fetch_team_roster(team_abbreviation: str) -> list[dict[str, Any]]:
+    """
+    Fetch the full roster for an NBA team from the ESPN API.
+
+    Uses ``https://site.api.espn.com/apis/site/v2/sports/basketball/nba/teams/{slug}/roster``
+    and extracts each active player's name, position abbreviation, salary,
+    and player ID.
+
+    Results are cached for 1 hour per team to reduce API calls.
+
+    Args:
+        team_abbreviation: Three-letter team abbreviation (e.g. ``"BOS"``).
+
+    Returns:
+        List of player dicts with keys: ``name``, ``position``, ``salary``,
+        ``player_id``, ``jersey``.  Sorted by salary descending.
+    """
+    now = datetime.utcnow()
+
+    # Check cache
+    if team_abbreviation in _ROSTER_CACHE and team_abbreviation in _ROSTER_CACHE_AT:
+        age = (now - _ROSTER_CACHE_AT[team_abbreviation]).total_seconds()
+        if age < _ROSTER_CACHE_TTL:
+            return _ROSTER_CACHE[team_abbreviation]
+
+    slug = _ESPN_TEAM_SLUGS.get(team_abbreviation, team_abbreviation.lower())
+    url = f"https://site.api.espn.com/apis/site/v2/sports/basketball/nba/teams/{slug}/roster"
+
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as e:
+        print(f"[_fetch_team_roster] Failed to fetch roster for {team_abbreviation}: {e}")
+        return _ROSTER_CACHE.get(team_abbreviation, [])
+
+    athletes = data.get("athletes", [])
+    roster: list[dict[str, Any]] = []
+
+    for athlete in athletes:
+        # Only include active players
+        status = athlete.get("status", {})
+        if status.get("type", "").lower() != "active":
+            continue
+
+        # Skip injured players (marked as "Out")
+        injuries = athlete.get("injuries", [])
+        is_out = any(
+            inj.get("status", "").lower() == "out"
+            for inj in injuries
+        )
+        if is_out:
+            continue
+
+        position = athlete.get("position", {})
+        contract = athlete.get("contract", {})
+        salary = contract.get("salary", 0) or 0
+
+        roster.append({
+            "name": athlete.get("displayName", "Unknown"),
+            "position": position.get("abbreviation", ""),
+            "salary": salary,
+            "player_id": str(athlete.get("id", "")),
+            "jersey": athlete.get("jersey", ""),
+        })
+
+    # Sort by salary descending
+    roster.sort(key=lambda p: p["salary"], reverse=True)
+
+    # Update cache
+    _ROSTER_CACHE[team_abbreviation] = roster
+    _ROSTER_CACHE_AT[team_abbreviation] = now
+
+    return roster
+
+
+def _pick_starters_by_salary(roster: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """
+    Select a starting five from a roster based on highest salary per position.
+
+    NBA standard starting lineup: 2 Guards (G), 2 Forwards (F), 1 Center (C).
+    For each position bucket, the highest-paid available (active, not injured)
+    players are selected.  If a position bucket can't be filled, the next
+    highest-paid remaining player is chosen regardless of position.
+
+    Args:
+        roster: List of player dicts (as returned by ``_fetch_team_roster``),
+                sorted by salary descending.
+
+    Returns:
+        List of up to 5 player dicts representing the projected starters,
+        each with keys: ``name``, ``position``, ``salary``, ``player_id``,
+        ``jersey``.
+    """
+    # Position buckets: how many starters we need per position group
+    needs = {"G": 2, "F": 2, "C": 1}
+    starters: list[dict[str, Any]] = []
+    used_ids: set[str] = set()
+
+    # First pass: fill each position bucket with highest-paid players
+    for pos, count in needs.items():
+        candidates = [
+            p for p in roster
+            if p["position"] == pos and p["player_id"] not in used_ids
+        ]
+        for player in candidates[:count]:
+            starters.append(player)
+            used_ids.add(player["player_id"])
+
+    # Second pass: if we have fewer than 5, fill with highest-paid remaining
+    if len(starters) < 5:
+        remaining = [p for p in roster if p["player_id"] not in used_ids]
+        for player in remaining:
+            if len(starters) >= 5:
+                break
+            starters.append(player)
+            used_ids.add(player["player_id"])
+
+    return starters
+
+
+def fetch_salary_based_lineups(game_date: str) -> dict[str, Any]:
+    """
+    Build projected starting lineups using the highest-paid players per position.
+
+    Instead of waiting for ESPN to publish actual starters (which happens
+    only around tip-off), this function uses each team's roster and current
+    contract salary data to project a starting five: the top-paid Guard (×2),
+    Forward (×2), and Center (×1) who are active and not listed as "Out".
+
+    Workflow:
+        1. Fetch the ESPN scoreboard for ``game_date`` to discover games.
+        2. For each team in those games, fetch the full roster (cached 1 hr).
+        3. Pick the top-paid player per position slot as the projected starter.
+
+    Args:
+        game_date: Date string in ``YYYYMMDD`` format (e.g. ``"20260307"``).
+
+    Returns:
+        A dict shaped identically to ``fetch_espn_lineups()``::
+
+            {
+                "date": "20260307",
+                "lineup_status": "projected",
+                "method": "salary_based",
+                "games": [
+                    {
+                        "game_id": "...",
+                        "home_team": {
+                            "team_name": "...",
+                            "team_abbreviation": "...",
+                            "starters": [ { "name", "position", "salary",
+                                            "player_id", "jersey" }, ... ]
+                        },
+                        "away_team": { ... }
+                    },
+                    ...
+                ],
+                "total_games": int,
+            }
+    """
+    _ESPN_SCOREBOARD_URL = "https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard"
+    _TIMEOUT = 10
+
+    # 1. Discover games for the requested date
+    try:
+        resp = requests.get(_ESPN_SCOREBOARD_URL, params={"dates": game_date}, timeout=_TIMEOUT)
+        resp.raise_for_status()
+        events = resp.json().get("events", [])
+    except Exception as e:
+        print(f"[fetch_salary_based_lineups] scoreboard fetch failed: {e}")
+        return {
+            "date": game_date,
+            "lineup_status": "error",
+            "method": "salary_based",
+            "message": f"Failed to fetch scoreboard: {e}",
+            "games": [],
+            "total_games": 0,
+        }
+
+    if not events:
+        return {
+            "date": game_date,
+            "lineup_status": "not_available",
+            "method": "salary_based",
+            "message": "No games found for this date.",
+            "games": [],
+            "total_games": 0,
+        }
+
+    # 2. For each game, fetch rosters and build projected lineups
+    games: list[dict[str, Any]] = []
+
+    for event in events:
+        game_id = event.get("id", "")
+        competition = (event.get("competitions") or [{}])[0]
+
+        game_entry: dict[str, Any] = {"game_id": game_id}
+
+        for competitor in competition.get("competitors", []):
+            side = competitor.get("homeAway", "")  # "home" or "away"
+            team = competitor.get("team", {})
+            team_name = team.get("displayName", "")
+            team_abbrev = team.get("abbreviation", "")
+
+            # Fetch roster and pick starters
+            roster = _fetch_team_roster(team_abbrev)
+            starters = _pick_starters_by_salary(roster)
+
+            # Format starters for output (drop salary from public response, keep for transparency)
+            formatted_starters = [
+                {
+                    "name": p["name"],
+                    "position": p["position"],
+                    "salary": p["salary"],
+                    "player_id": p["player_id"],
+                    "jersey": p["jersey"],
+                }
+                for p in starters
+            ]
+
+            side_key = "home_team" if side == "home" else "away_team"
+            game_entry[side_key] = {
+                "team_name": team_name,
+                "team_abbreviation": team_abbrev,
+                "starters": formatted_starters,
+            }
+
+        games.append(game_entry)
+
+    return {
+        "date": game_date,
+        "lineup_status": "projected",
+        "method": "salary_based",
+        "message": "Lineups are projected based on highest-paid active players per position (2G, 2F, 1C).",
+        "games": games,
+        "total_games": len(games),
+    }
+
 # deque to keep track of timestamps of the last 10 requests
 _SPORTSGAMEODDS_REQUEST_TIMES: deque[float] = deque(maxlen=10)
 _SPORTSGAMEODDS_LOCK = threading.Lock()


### PR DESCRIPTION
Switched to ESPN's roster API which has salary data available at all times. We now project starting lineups by picking the highest-paid active, non-injured player at each position (2G, 2F, 1C).

Changes
[util.py](vscode-file://vscode-app/c:/Users/naema/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — Added [fetch_salary_based_lineups()](vscode-file://vscode-app/c:/Users/naema/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and helpers to fetch rosters, filter out injured players, and pick starters by salary
[main.py](vscode-file://vscode-app/c:/Users/naema/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — Updated /api/v1/lineups/{game_date} and /api/props to use the new function

Tests for Lakers and Clippers. Also checks for the "Out" keyword in the ESPN API to make sure that it does not include players that are not playing.

LOS ANGELES LAKERS (LAL)
  1. Luka Doncic              G   $54,126,450
  2. Austin Reaves             G   $13,937,574
  3. LeBron James              F   $52,627,153
  4. Rui Hachimura             F   $18,259,259
  5. Deandre Ayton             C   $ 8,104,000

LOS ANGELES CLIPPERS (LAC)
  1. Darius Garland            G   $39,446,090
  2. Bogdan Bogdanovic         G   $16,020,000
  3. Kawhi Leonard             F   $50,000,000
  4. Derrick Jones Jr.         F   $10,000,000
  5. Brook Lopez               C   $ 8,750,000