### PR TITLE
refactor props endpoint to one player

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -376,52 +376,14 @@ async def games_by_date(date: str):
         print(f"Error in games by date: {e}")
         return []
 
-@app.get("/api/props/odds")
-def get_player_props_odds(game_date: str):
+@app.get("/api/props/odds/{player_name}")
+def get_player_props_odds(player_name: str):
     """
-    Returns player PTS, REB, and AST props for all players in lineups on a certain date.
+    Returns player PTS, REB, and AST props for a certain player.
     Also includes over/under lines from different bookmakers (platforms).
-    Uses salary-based projected lineups so data is available before tip-off.
     """
-    lineups = fetch_espn_lineups(game_date)
-    if not lineups:
-        return {
-            "error": "No lineups found",
-            "date": game_date,
-            "games": []
-        }
-    
-    def get_player_name(player_name: str) -> str:
-        """
-        Parses player name to not include suffixes (e.g. Jr, III, etc.)
-        """
-        player_name_components = player_name.split(" ")
-        if len(player_name_components) > 2:
-            return player_name_components[0] + " " + player_name_components[1]
-        return player_name
-
-    props: dict[str, dict[str, any]] = {}
-
-    for game in lineups["games"]:
-        for side in ("home_team", "away_team"):
-            team = game.get(side) or {}
-            team_abbrev = team.get("team_abbreviation")
-            starters = team.get("starters") or []
-
-            if not team_abbrev:
-                continue
-
-            team_props: dict[str, any] = {}
-            for player in starters:
-                raw_name = player.get("name", "")
-                player_name = get_player_name(raw_name)
-                player_props = fetch_player_props(player_name)
-                team_props[player_name] = player_props
-
-            props[team_abbrev] = team_props
-
-    return props
-
+    player_props = fetch_player_props(player_name)
+    return player_props
 
 # Standings route
 @app.get("/api/standings")

--- a/backend/util.py
+++ b/backend/util.py
@@ -797,6 +797,7 @@ def get_player_props(player_name: str) -> dict[str, Any]:
     Args:
         player_name: The name of the player to get props for.
     """
+    player_name = player_name.replace("-", "")
     player_entity_id = "_".join(player_name.split(" ")).upper() + "_1_NBA"
     odd_ids = (
         f"points-{player_entity_id}-game-ou-over,points-{player_entity_id}-game-ou-under,"
@@ -807,7 +808,6 @@ def get_player_props(player_name: str) -> dict[str, Any]:
 
     try:
         _wait_sportsgameodds_rate_limit()
-        print(url)
         response = requests.get(url)
         _record_sportsgameodds_request()
         data = response.json()


### PR DESCRIPTION
Changed get_player_props to get player props for certain player name instead of every player returned by lineups function. This can be called on frontend when user clicks on player card on props page to load the PRA modal. 

The player's full name should be passed in, the function parses the name correctly so fit the API. (removes hyphens, suffixes)

RETURN PAYLOAD:
{'points': {'over': {'draftkings': {'odds': '-108', 'line': '15.5'}, 'fanduel': {'odds': '-112', 'line': '15.5'}, 'bovada': {'odds': '+100', 'line': '15.5'}, 'betmgm': {'odds': '-140', 'line': '14.5'}, 'espnbet': {'odds': '-115', 'line': '15.5'}}, 'under': {'draftkings': {'odds': '-118', 'line': '15.5'}, 'fanduel': {'odds': '-118', 'line': '15.5'}, 'bovada': {'odds': '-130', 'line': '15.5'}, 'betmgm': {'odds': '+105', 'line': '14.5'}, 'espnbet': {'odds': '-115', 'line': '15.5'}}}, 'rebounds': {'over': {'draftkings': {'odds': '-152', 'line': '6.5'}, 'fanduel': {'odds': '-120', 'line': '6.5'}, 'bovada': {'odds': '-145', 'line': '6.5'}, 'betmgm': {'odds': '+110', 'line': '7.5'}, 'espnbet': {'odds': '-125', 'line': '6.5'}}, 'under': {'draftkings': {'odds': '+115', 'line': '6.5'}, 'fanduel': {'odds': '-110', 'line': '6.5'}, 'bovada': {'odds': '+105', 'line': '6.5'}, 'betmgm': {'odds': '-150', 'line': '7.5'}, 'espnbet': {'odds': '-105', 'line': '6.5'}}}, 'assists': {'over': {'draftkings': {'odds': '-163', 'line': '1.5'}, 'betmgm': {'odds': '-150', 'line': '1.5'}, 'bovada': {'odds': '-160', 'line': '1.5'}}, 'under': {'betmgm': {'odds': '+110', 'line': '1.5'}, 'draftkings': {'odds': '+123', 'line': '1.5'}, 'bovada': {'odds': '+120', 'line': '1.5'}}}}