### PR TITLE
reworked the data pipeline to now save datapoints of props onto db

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -452,5 +452,86 @@ def get_historical_team_stats(game_id: str) -> dict:
     }
 
 
+def _save_probability_history_sync(game_id: str, history: list[dict]) -> int:
+    """
+    Bulk-insert probability history snapshots for a completed game
+    into game_probability_history.  Existing rows for the same game_id
+    are deleted first so re-saves are idempotent.
+    """
+    if not history:
+        return 0
+
+    gid = int(game_id)
+    with get_db() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM game_probability_history WHERE game_id = %s",
+                (gid,),
+            )
+            for snap in history:
+                cur.execute(
+                    """
+                    INSERT INTO game_probability_history
+                        (game_id, clock_display, home_team_score, away_team_score,
+                         home_win_probability, away_win_probability)
+                    VALUES (%s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        gid,
+                        str(snap.get("clock", "")),
+                        int(snap.get("home_score", 0) or 0),
+                        int(snap.get("away_score", 0) or 0),
+                        float(snap.get("home_win_prob", 0)),
+                        float(snap.get("away_win_prob", 0)),
+                    ),
+                )
+    return len(history)
+
+
+async def save_probability_history(game_id: str, history: list[dict]) -> int:
+    """Async wrapper: persist probability history for a finished game."""
+    import asyncio
+    try:
+        count = await asyncio.to_thread(_save_probability_history_sync, game_id, history)
+        if count:
+            print(f"[db] saved {count} probability snapshots for game {game_id}")
+        return count
+    except Exception as e:
+        print(f"[db] failed to save probability history for game {game_id}: {e}")
+        return 0
+
+
+def get_probability_history(game_id: str) -> list[dict]:
+    """
+    Fetch stored probability history for a past game from the database.
+    Returns a list of snapshot dicts matching the in-memory format.
+    """
+    try:
+        gid = int(game_id)
+    except (TypeError, ValueError):
+        return []
+
+    rows = execute_query(
+        """
+        SELECT clock_display, home_team_score, away_team_score,
+               home_win_probability, away_win_probability
+        FROM game_probability_history
+        WHERE game_id = %s
+        ORDER BY probability_id ASC
+        """,
+        (gid,),
+    )
+    return [
+        {
+            "clock": row["clock_display"],
+            "home_score": row["home_team_score"],
+            "away_score": row["away_team_score"],
+            "home_win_prob": row["home_win_probability"],
+            "away_win_prob": row["away_win_probability"],
+        }
+        for row in rows
+    ]
+
+
 if __name__ == "__main__":
     test_connection()

--- a/backend/main.py
+++ b/backend/main.py
@@ -24,9 +24,10 @@ from database import (
     save_completed_games_to_db,
     past_game_row_to_dashboard_game,
     get_historical_team_stats,
+    get_probability_history,
+    save_probability_history,
     is_game_final,
 )
-from database import fetch_game_history, save_completed_games_to_db
 from services.live_props.poller import props_poll_loop
 from services.live_props.service import compute_live_props_snapshot
 from services.live_props.store import get_snapshot, set_snapshot
@@ -88,6 +89,13 @@ async def update_games_and_probabilities():
         to_save = [m for m in all_games_stats if str(m.get("game_id")) in newly_final_ids]
         print(f"to_save: {to_save}")
         await save_completed_games_to_db(to_save)
+
+        # Persist probability history for each newly finished game
+        for g in newly_final:
+            gid = str(g["game_id"])
+            history = app_state.PROBABILITY_HISTORY.get(gid, [])
+            if history:
+                await save_probability_history(gid, history)
 
         # update in-memory store with finished game IDs
         for g in newly_final:
@@ -467,9 +475,11 @@ def single_game_stats(game_id: str):
         hist = get_historical_team_stats(game_id)
         if not hist:
             return {"error": "Game not found"}, 404
-        hist["probability_history"] = list(
-            app_state.PROBABILITY_HISTORY.get(game_id, [])
-        )
+        # Try in-memory first (game just finished), fall back to database
+        prob_hist = app_state.PROBABILITY_HISTORY.get(game_id, [])
+        if not prob_hist:
+            prob_hist = get_probability_history(game_id)
+        hist["probability_history"] = list(prob_hist)
         return hist
     
     # Fetch full stats for this specific game

--- a/backend/sports-betting-db.sql
+++ b/backend/sports-betting-db.sql
@@ -115,17 +115,15 @@ CREATE TABLE game_probability_history (
     probability_id SERIAL PRIMARY KEY,
     game_id INT NOT NULL,
     calculation_timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    game_time_elapsed TIME NOT NULL,
-    quarter INT,
+    clock_display VARCHAR(50) NOT NULL,
     home_team_score INT NOT NULL,
     away_team_score INT NOT NULL,
     home_win_probability FLOAT NOT NULL,
-    away_win_probability FLOAT NOT NULL,
-    llm_model_version VARCHAR(50)
+    away_win_probability FLOAT NOT NULL
 );
 
--- Index for efficient querying of probability history by game and time
-CREATE INDEX idx_game_timestamp ON game_probability_history(game_id, calculation_timestamp);
+-- Index for efficient querying of probability history by game
+CREATE INDEX idx_prob_history_game_id ON game_probability_history(game_id);
 
 -- Table to hold info for the players that are currently playing in the game
 CREATE TABLE player_in_game_info (


### PR DESCRIPTION
Changes

Added [save_probability_history()](vscode-file://vscode-app/c:/Users/naema/AppData/Local/Programs/Microsoft%20VS%20Code/61b3d0ab13/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — bulk-inserts in-memory snapshots to game_probability_history when a game finishes
Added [get_probability_history()](vscode-file://vscode-app/c:/Users/naema/AppData/Local/Programs/Microsoft%20VS%20Code/61b3d0ab13/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — reads saved snapshots from DB for past games

After saving a completed game, now also calls [save_probability_history()](vscode-file://vscode-app/c:/Users/naema/AppData/Local/Programs/Microsoft%20VS%20Code/61b3d0ab13/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to persist the graph data
[/api/games/stats/{game_id}](vscode-file://vscode-app/c:/Users/naema/AppData/Local/Programs/Microsoft%20VS%20Code/61b3d0ab13/resources/app/out/vs/code/electron-browser/workbench/workbench.html) now falls back to DB when in-memory history is empty (past games)
[sports-betting-db.sql](vscode-file://vscode-app/c:/Users/naema/AppData/Local/Programs/Microsoft%20VS%20Code/61b3d0ab13/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Updated game_probability_history table: replaced game_time_elapsed TIME + quarter INT + llm_model_version with clock_display to match actual app data format
